### PR TITLE
.tracked_files should include relative, not absolute, paths

### DIFF
--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -373,16 +373,6 @@ elsif command == "update"
     exit(1)
   end
 
-  target_dir = File.dirname(path)
-  # If the config file is buried in a directory starting with '.', bubble up to the
-  # directory that contains that '.' directory.
-  nested_dirs = target_dir
-                  .split("/")
-                  .reverse
-                  .drop_while{ |dir| !dir.start_with?(".") }
-  nested_dirs = nested_dirs.drop(1) if nested_dirs.length > 0 && nested_dirs[0].start_with?(".")
-  target_dir = nested_dirs.reverse.join("/") if nested_dirs.length > 0
-
   updates = []
   puts "Fetching code from #{client.url}"
 
@@ -395,8 +385,8 @@ elsif command == "update"
     project.generators.each do |generator|
       generator.targets.each do |target|
         puts "  #{project.org}/#{project.name}/#{project.version}/#{generator.name}..."
-        base_target_path = File.join(target_dir, target)
-        reference_target_path = File.join(target_dir, ApibuilderCli::Config::APIBUILDER_LOCAL_DIR, target)
+        base_target_path = File.join(app_config.project_dir, target)
+        reference_target_path = File.join(app_config.project_dir, ApibuilderCli::Config::APIBUILDER_LOCAL_DIR, target)
 
         begin
           code = client.code.get(project.org, project.name, project.version, generator.name).files

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -378,8 +378,7 @@ elsif command == "update"
 
   app_config = ApibuilderCli::AppConfig.new(:path => path)
 
-  pwd = `pwd`.strip
-  tracked_files = ApibuilderCli::FileTracker.new(pwd)
+  tracked_files = ApibuilderCli::FileTracker.new(app_config.project_dir)
 
   app_config.code.projects.map do |project|
     project.generators.each do |generator|
@@ -409,7 +408,7 @@ elsif command == "update"
               target_path = File.directory?(final_target_path) ? File.join(final_target_path, file.name) : final_target_path
               existing_source = File.exists?(target_path) ? IO.read(target_path).strip : ""
 
-              print "    " + target_path.sub(/^#{pwd}\/?/, '') + ": "
+              print "    " + target_path.sub(/^#{app_config.project_dir}\/?/, '') + ": "
               if file_is_scaffolding?(file)
                 if existing_source == ""
                   puts "new scaffolding file"

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -387,9 +387,9 @@ elsif command == "update"
   puts "Fetching code from #{client.url}"
 
   app_config = ApibuilderCli::AppConfig.new(:path => path)
-  tracked_files = ApibuilderCli::FileTracker.new
 
   pwd = `pwd`.strip
+  tracked_files = ApibuilderCli::FileTracker.new(pwd)
 
   app_config.code.projects.map do |project|
     project.generators.each do |generator|

--- a/src/apibuilder-cli/app_config.rb
+++ b/src/apibuilder-cli/app_config.rb
@@ -5,7 +5,7 @@ module ApibuilderCli
 
     DEFAULT_FILENAMES = ["#{ApibuilderCli::Config::APIBUILDER_LOCAL_DIR}/config", ".apibuilder", ".apidoc"] unless defined?(DEFAULT_FILENAMES)
 
-    attr_reader :settings, :code
+    attr_reader :settings, :code, :project_dir
 
     def AppConfig.default_path
       path = DEFAULT_FILENAMES.find { |p| File.exists?(p) }
@@ -26,6 +26,19 @@ module ApibuilderCli
       path
     end
       
+    def AppConfig.parse_project_dir(path)
+      project_dir = File.dirname(path)
+      # If the config file is buried in a directory starting with '.', bubble up to the
+      # directory that contains that '.' directory.
+      nested_dirs = project_dir
+                      .split("/")
+                      .reverse
+                      .drop_while{ |dir| !dir.start_with?(".") }
+      nested_dirs = nested_dirs.drop(1) if nested_dirs.length > 0 && nested_dirs[0].start_with?(".")
+      project_dir = nested_dirs.reverse.join("/") if nested_dirs.length > 0
+      project_dir
+    end
+
     def initialize(opts={})
       @path = Preconditions.assert_class(opts.delete(:path) || AppConfig.default_path, String)
       Preconditions.check_state(File.exists?(@path), "Apibuilder application config file[#{@path}] not found")
@@ -62,6 +75,8 @@ module ApibuilderCli
       end.flatten
 
       @code = Code.new(code_projects)
+
+      @project_dir = AppConfig.parse_project_dir(@path)
     end
 
     class Code

--- a/src/apibuilder-cli/file_tracker.rb
+++ b/src/apibuilder-cli/file_tracker.rb
@@ -2,18 +2,18 @@ module ApibuilderCli
 
   class FileTracker
 
-    def FileTracker.default_path
-      "#{ApibuilderCli::Config::APIBUILDER_LOCAL_DIR}/.tracked_files"
+    def FileTracker.default_path(project_dir)
+      Util.file_join(project_dir, ApibuilderCli::Config::APIBUILDER_LOCAL_DIR, ".tracked_files")
     end
 
     # Options:
     #   :path => Mostly here for injecting test config
-    def initialize(pwd, opts={})
-      @path = Preconditions.assert_class(opts.delete(:path) || FileTracker.default_path, String)
+    def initialize(project_dir, opts={})
+      @project_dir = Preconditions.check_not_blank(project_dir, "ERROR: Missing project_dir")
+      @path = Preconditions.assert_class(opts.delete(:path) || FileTracker.default_path(@project_dir), String)
       @previous = {}
       @current = {}
       @current_raw = []
-      @pwd = pwd
       if File.exists?(@path)
         contents = IO.read(@path).strip
         if contents != ""
@@ -50,7 +50,7 @@ module ApibuilderCli
             files - @current_raw
           }
         }
-      }.flatten.sort
+      }.flatten.sort.map{|f| Util.file_join(@project_dir, f)}
     end
 
     # Keep track of the given file
@@ -59,7 +59,7 @@ module ApibuilderCli
       Preconditions.assert_class(project, String)
       Preconditions.assert_class(generator, String)
       Preconditions.assert_class(file, String)
-      file = file.sub(/^#{@pwd}\/?/, '')
+      file = file.sub(/^#{@project_dir}\/?/, '')
 
       @current[org] = {} if @current[org].nil?
       @current[org][project] = {} if @current[org][project].nil?

--- a/src/apibuilder-cli/file_tracker.rb
+++ b/src/apibuilder-cli/file_tracker.rb
@@ -8,11 +8,12 @@ module ApibuilderCli
 
     # Options:
     #   :path => Mostly here for injecting test config
-    def initialize(opts={})
+    def initialize(pwd, opts={})
       @path = Preconditions.assert_class(opts.delete(:path) || FileTracker.default_path, String)
       @previous = {}
       @current = {}
       @current_raw = []
+      @pwd = pwd
       if File.exists?(@path)
         contents = IO.read(@path).strip
         if contents != ""
@@ -58,6 +59,7 @@ module ApibuilderCli
       Preconditions.assert_class(project, String)
       Preconditions.assert_class(generator, String)
       Preconditions.assert_class(file, String)
+      file = file.sub(/^#{@pwd}\/?/, '')
 
       @current[org] = {} if @current[org].nil?
       @current[org][project] = {} if @current[org][project].nil?

--- a/src/apibuilder-cli/util.rb
+++ b/src/apibuilder-cli/util.rb
@@ -2,6 +2,11 @@ module ApibuilderCli
 
   module Util
 
+    def Util.file_join(*args)
+      args.select!{|s| s.to_s.strip != "" }
+      File.join(*args)
+    end
+
     # Writes contents to a temp file, returning the path
     def Util.write_to_temp_file(contents)
       tmp = Tempfile.new('apibuilder-cli')

--- a/test/spec/lib/app_config_spec.rb
+++ b/test/spec/lib/app_config_spec.rb
@@ -77,6 +77,20 @@ code:
       expect(bar.generators.map(&:name).sort).to eq(["ruby_client"])
     end
 
+    it "sets the project_dir" do
+      app_config = ApibuilderCli::AppConfig.new(:path => @sample_file)
+      expect(app_config.project_dir).to eq(File.dirname(@sample_file))
+    end
+  end
+
+  describe "ApibuilderCli::AppConfig.parse_project_dir" do
+    it "should correctly find the project root" do
+      expect(ApibuilderCli::AppConfig.parse_project_dir("/src/my-project/.apibuilder/config")).to eq("/src/my-project")
+      expect(ApibuilderCli::AppConfig.parse_project_dir("/src/my-project/.foo/.apibuilder/config")).to eq("/src/my-project/.foo")
+      expect(ApibuilderCli::AppConfig.parse_project_dir("/src/my-project/.apibuilder/my/buried/config")).to eq("/src/my-project")
+      expect(ApibuilderCli::AppConfig.parse_project_dir("/src/my-project/.apibuilder")).to eq("/src/my-project")
+      expect(ApibuilderCli::AppConfig.parse_project_dir("/src/my-project/apibuilder.config")).to eq("/src/my-project")
+    end
   end
 
 end

--- a/test/spec/lib/file_tracker_spec.rb
+++ b/test/spec/lib/file_tracker_spec.rb
@@ -26,7 +26,7 @@ foo:
 
       before do
         @file_path = is_empty ? @empty_destination : @sample_file
-        @files = ApibuilderCli::FileTracker.new(:path => @file_path)
+        @files = ApibuilderCli::FileTracker.new(`pwd`.strip, :path => @file_path)
         @previous_count = @files.to_cleanup.size
       end
 
@@ -59,7 +59,7 @@ baz:
   describe "with some files tracked" do
 
     before do
-      @files = ApibuilderCli::FileTracker.new(:path => @sample_file)
+      @files = ApibuilderCli::FileTracker.new(`pwd`.strip, :path => @sample_file)
     end
 
     describe "#save" do
@@ -89,6 +89,17 @@ apicollective:
 """
       end
 
+      it "should not include current directory" do
+        pwd = `pwd`.strip
+        @files.track!("apicollective", "apibuilder", "play_2_x_routes", "#{pwd}/conf/routes")
+        @files.save!
+        expect(IO.read(@sample_file)).to eq """---
+apicollective:
+  apibuilder:
+    play_2_x_routes:
+    - conf/routes
+"""
+      end
     end
 
     describe "#to_cleanup" do

--- a/test/spec/lib/file_tracker_spec.rb
+++ b/test/spec/lib/file_tracker_spec.rb
@@ -16,7 +16,7 @@ apicollective:
 foo:
   bar:
     ruby_client:
-    - /tmp/client.rb
+    - tmp/client.rb
     """.strip)
     @empty_destination = ApibuilderCli::Util.write_to_temp_file("")
   end
@@ -105,22 +105,26 @@ apicollective:
     describe "#to_cleanup" do
 
       it "should flatten files across org/project/generator" do
-        expect(@files.to_cleanup).to match_array ["/tmp/client.rb", "api/conf/routes", "generated/app/ApibuilderClient.scala", "generated/app/ApibuilderSpec.scala"]
+        expect(@files.to_cleanup).to match_array [rel("api/conf/routes"), rel("generated/app/ApibuilderClient.scala"), rel("generated/app/ApibuilderSpec.scala"), rel("tmp/client.rb")]
       end
 
       it "should not list files used by other org/project/generator" do
-        @files.track!("apicollective", "apibuilder", "play_2_x_routes", "/tmp/client.rb")
-        expect(@files.to_cleanup).to match_array ["api/conf/routes", "generated/app/ApibuilderClient.scala", "generated/app/ApibuilderSpec.scala"]
+        @files.track!("apicollective", "apibuilder", "play_2_x_routes", "tmp/client.rb")
+        expect(@files.to_cleanup).to match_array [rel("api/conf/routes"), rel("generated/app/ApibuilderClient.scala"), rel("generated/app/ApibuilderSpec.scala")]
       end
 
       it "should remove current files" do
         @files.track!("apicollective", "apibuilder", "play_2_x_routes", "api/conf/routes")
         @files.track!("apicollective", "apibuilder", "play_2_3_client", "generated/app/ApibuilderClient.scala")
-        expect(@files.to_cleanup).to match_array ["/tmp/client.rb", "generated/app/ApibuilderSpec.scala"]
+        expect(@files.to_cleanup).to match_array [rel("generated/app/ApibuilderSpec.scala"), rel("tmp/client.rb")]
       end
 
     end
 
+  end
+
+  def rel(path)
+    File.join(`pwd`.strip, path)
   end
 
 end

--- a/test/spec/lib/util_spec.rb
+++ b/test/spec/lib/util_spec.rb
@@ -2,6 +2,17 @@ load File.join(File.dirname(__FILE__), '../../init.rb')
 
 describe ApibuilderCli::Util do
 
+  describe "Util.file_join" do
+    it "should eliminate nils" do
+      expect(ApibuilderCli::Util.file_join(nil, "foo", "bar")).to eq("foo/bar")
+    end
+
+    it "should eliminate empty strings" do
+      expect(ApibuilderCli::Util.file_join("", "foo", "bar")).to eq("foo/bar")
+      expect(ApibuilderCli::Util.file_join("  ", "foo", "bar")).to eq("foo/bar")
+    end
+  end
+
   it "Util.write_to_temp_file" do
     path = ApibuilderCli::Util.write_to_temp_file("foo")
     expect(IO.read(path)).to eq("foo")


### PR DESCRIPTION
This will prevent commit cruft when updating from different machines.