### PR TITLE
Default version suggestion to current base tag name with -dev appended

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ For example:
 ```
 bin/apibuilder upload apicollective apibuilder-api apibuilder-api/api.json --version 1.0.1
 ```
+The `version` parameter is optional. If omitted a suggestion will be made using the currently
+tagged version appended with `-dev`.
 
 ## update
 

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -330,8 +330,8 @@ elsif command == "upload"
   if version.empty?
     default_version = ""
 
-    if system("git describe 2> /dev/null")
-      default_version = `git describe`.strip
+    if system("git describe &> /dev/null")
+      default_version = `git describe --abbrev=0`.strip + "-dev"
     end
 
     print "Version"


### PR DESCRIPTION
Simplify default version suggestion to current base tag name with a `-dev` appendix.

This makes the default more friendly to new users.