### PR TITLE
Add branch name to autogenerated version number 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ bin/apibuilder upload apicollective apibuilder-api apibuilder-api/api.json --ver
 
 The `--force` flag will allow you to re-upload an api.json even if there are no changes since the previously uploaded version.
 
-When using the `--silent` flag, the suggested tag will be automatically used. This is useful for automated uploading vis git hooks and/or CD pipelines.
+When using the `--silent` flag, the suggested tag will be automatically used. This is useful for automated uploading via git hooks and/or CD pipelines.
 
 ## update
 
@@ -180,6 +180,22 @@ Supported settings include:
     `apibuilder update`, we will create the subdirectories as specified by
     the code generator.
 
+
+## clean
+
+Delete versions in ApiBuilder that are not tagged in the source repo.
+
+```
+bin/apibuilder clean <organization key> <application key> [--silent]
+```
+
+For example:
+
+```
+bin/apibuilder clean apicollective apibuilder-api
+```
+
+When using the `--silent` flag, the suggested versions will be automatically deleted without prompting. This is useful for automated cleanup via git hooks and/or CD pipelines.
 
 ## cli itself
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Supported settings include:
 Delete versions in ApiBuilder that are not tagged in the source repo.
 
 ```
-bin/apibuilder clean <organization key> <application key> [--branch <branch name>] [--silent]
+bin/apibuilder clean <organization key> <application key> [--branch <branch name>] [--silent] [--legacy]
 ```
 
 For example:
@@ -196,6 +196,8 @@ bin/apibuilder clean apicollective apibuilder-api --branch dev
 ```
 
 When using the `--silent` flag, the suggested versions will be automatically deleted without prompting. This is useful for automated cleanup via git hooks and/or CD pipelines.
+
+If you have versions that use the legacy default naming (i.e. that match the pattern `/^.*-\d+-g[0-9a-f]{7}$/`) and belong on a non-master branch, use the `--legacy` flag to interactively move those versions to the proper branch. You only need to run this once, at the point of migrating from the legacy naming to the branch naming. Afterwards, simply run `clean` without the `--legacy` flag.
 
 ## cli itself
 

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ Supported settings include:
 Delete versions in ApiBuilder that are not tagged in the source repo.
 
 ```
-bin/apibuilder clean <organization key> <application key> [--silent]
+bin/apibuilder clean <organization key> <application key> [--branch <branch name>] [--silent]
 ```
 
 For example:
 
 ```
-bin/apibuilder clean apicollective apibuilder-api
+bin/apibuilder clean apicollective apibuilder-api --branch dev
 ```
 
 When using the `--silent` flag, the suggested versions will be automatically deleted without prompting. This is useful for automated cleanup via git hooks and/or CD pipelines.

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -51,7 +51,7 @@
 #    parameter. Invokes the apibuilder code generators specified in the
 #    configuration file.
 #
-# apibuilder clean apicollective apibuilder-api [--silent]
+# apibuilder clean apicollective apibuilder-api [--branch branch-name] [--silent]
 #  - Interactively deletes from ApiBuilder any version not tagged in the source repo.
 #  - Using the --silent flag will delete versions without asking.
 #
@@ -508,6 +508,8 @@ elsif command == "clean"
   application = ARGV.shift.to_s.strip
 
   args = ApibuilderCli::Args.parse(ARGV)
+  branch = args[:branch].to_s.strip.downcase
+  branch = "master" if branch.empty?
   silent = args.key?(:silent)
   limit = 50
 
@@ -530,28 +532,43 @@ elsif command == "clean"
     offset += 1
     break if current_page.size < limit
   end
-  to_delete = versions - ApibuilderCli::Git.tag_list
-  if to_delete.size == 0
-    puts "API is clean"
-  else
-    to_delete.each do |version|
-      delete = false
-      if silent
-        delete = true
-      else
-        print "Delete #{version} [Yn]? "
-        answer = $stdin.gets
-        delete = answer.strip.empty? || answer.strip.downcase == "y"
-      end
-      if delete
-        client.versions.delete_by_application_key_and_version(org, application, version)
-        puts "deleted #{version}..."
-      else
-        puts "skipping #{version}..."
+
+  ApibuilderCli::Git.in_branch(branch) do
+    to_delete = versions - ApibuilderCli::Git.tag_list.map { |tag|
+      branch == "master" ? tag : "#{tag}#{ApibuilderCli::Git.branch_suffix(branch)}"
+    }
+    if branch == "master"
+      to_delete.reject! { |version|
+        # Ignore versions with a branch delimiter.
+        version.match(/-b[0-9a-f]{7}-.+$/)
+      }
+    else
+      to_delete.select! { |version|
+        # Only consider versions that match the branch.
+        version.end_with?(ApibuilderCli::Git.branch_suffix(branch))
+      }
+    end
+    if to_delete.size == 0
+      puts "API is clean"
+    else
+      to_delete.each do |version|
+        delete = false
+        if silent
+          delete = true
+        else
+          print "Delete #{version} [Yn]? "
+          answer = $stdin.gets
+          delete = answer.strip.empty? || answer.strip.downcase == "y"
+        end
+        if delete
+          client.versions.delete_by_application_key_and_version(org, application, version)
+          puts "deleted #{version}..."
+        else
+          puts "skipping #{version}..."
+        end
       end
     end
   end
-
 
 elsif command == "cli"
   subcommand = ARGV.shift.to_s.strip

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -51,7 +51,7 @@
 #    parameter. Invokes the apibuilder code generators specified in the
 #    configuration file.
 #
-# apibuilder clean apicollective apibuilder-api [--branch branch-name] [--silent]
+# apibuilder clean apicollective apibuilder-api [--branch branch-name] [--silent] [--legacy]
 #  - Interactively deletes from ApiBuilder any version not tagged in the source repo.
 #  - Using the --silent flag will delete versions without asking.
 #
@@ -112,20 +112,17 @@ end
 def head_of_latest_uploaded_version(org, application, client)
   found = nil
   0.upto(99).each do |i|
-    # Attempt both naming with branch and the legacy version without branch.
-    [ApibuilderCli::Git.generate_version(i), ApibuilderCli::Git.generate_version(i, true)].each do |version|
-      begin
-        apibuilder_version = client.versions.get_by_application_key_and_version(org, application, version)
-        found = i
-        break
-      rescue Io::Apibuilder::Api::V0::HttpClient::ServerError => e
-        # Continue looking when the version is not found; fail for other exceptions.
-        if e.code != 404
-          raise e
-        end
+    version = ApibuilderCli::Git.generate_version(i)
+    begin
+      apibuilder_version = client.versions.get_by_application_key_and_version(org, application, version)
+      found = i
+      break
+    rescue Io::Apibuilder::Api::V0::HttpClient::ServerError => e
+      # Continue looking when the version is not found; fail for other exceptions.
+      if e.code != 404
+        raise e
       end
     end
-    break unless found.nil?
   end
   found
 end
@@ -212,6 +209,23 @@ def handle_server_error(e)
     end
   else
     $stderr.puts "#{e.to_s}"
+  end
+end
+
+def upload_version(client, org, application, version, data, path = "")
+  original_form = Io::Apibuilder::Api::V0::Models::OriginalForm.new(:data => data)
+  form = Io::Apibuilder::Api::V0::Models::VersionForm.new(:original_form => original_form)
+
+  print "Uploading #{path == '' ? 'data' : path} to #{client.url}/#{org}/#{application}/#{version} ... "
+  begin
+    client.versions.put_by_application_key_and_version(org, application, version, form)
+    puts "success"
+  rescue Exception => e
+    handle_server_error(e)
+  rescue Exception => e
+    puts ""
+    puts "** ERROR: #{e}"
+    exit(1)
   end
 end
 
@@ -397,20 +411,7 @@ elsif command == "upload"
   end
 
   unless version.empty?
-    original_form = Io::Apibuilder::Api::V0::Models::OriginalForm.new(:data => IO.read(path))
-    form = Io::Apibuilder::Api::V0::Models::VersionForm.new(:original_form => original_form)
-
-    print "Uploading #{path} to #{client.url}/#{org}/#{application}/#{version} ... "
-    begin
-      client.versions.put_by_application_key_and_version(org, application, version, form)
-      puts "success"
-    rescue Exception => e
-      handle_server_error(e)
-    rescue Exception => e
-      puts ""
-      puts "** ERROR: #{e}"
-      exit(1)
-    end
+    upload_version(client, org, application, version, IO.read(path), path)
   end
 
 elsif command == "update"
@@ -510,11 +511,17 @@ elsif command == "clean"
   args = ApibuilderCli::Args.parse(ARGV)
   branch = args[:branch].to_s.strip.downcase
   branch = "master" if branch.empty?
+  legacy = args.key?(:legacy)
   silent = args.key?(:silent)
   limit = 50
 
   if org.empty? || application.empty?
     puts "org, application are required"
+    exit(1)
+  end
+
+  if legacy && silent
+    puts "--legacy is intended to be interactive; please use either --legacy or --silent but not both."
     exit(1)
   end
 
@@ -553,14 +560,29 @@ elsif command == "clean"
     else
       to_delete.each do |version|
         delete = false
+        move_to_branch = ""
         if silent
           delete = true
+        elsif legacy
+          print "Move #{version} to branch? Enter branch name or leave blank to delete: "
+          answer = $stdin.gets
+          if answer.strip.empty?
+            delete = true
+          else
+            move_to_branch = answer.strip
+          end
         else
           print "Delete #{version} [Yn]? "
           answer = $stdin.gets
           delete = answer.strip.empty? || answer.strip.downcase == "y"
         end
         if delete
+          client.versions.delete_by_application_key_and_version(org, application, version)
+          puts "deleted #{version}..."
+        elsif move_to_branch != ""
+          app = client.versions.get_by_application_key_and_version(org, application, version)
+          new_version = "#{version}#{ApibuilderCli::Git.branch_suffix(move_to_branch)}"
+          upload_version(client, org, application, new_version, app.original.data)
           client.versions.delete_by_application_key_and_version(org, application, version)
           puts "deleted #{version}..."
         else

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -108,17 +108,20 @@ end
 def head_of_latest_uploaded_version(org, application, client)
   found = nil
   0.upto(99).each do |i|
-    version = ApibuilderCli::Git.safe_describe(i)
-    begin
-      apibuilder_version = client.versions.get_by_application_key_and_version(org, application, version)
-      found = i
-      break
-    rescue Io::Apibuilder::Api::V0::HttpClient::ServerError => e
-      # Continue looking when the version is not found; fail for other exceptions.
-      if e.code != 404
-        raise e
+    # Attempt both naming with branch and the legacy version without branch.
+    [ApibuilderCli::Git.generate_version(i), ApibuilderCli::Git.generate_version(i, true)].each do |version|
+      begin
+        apibuilder_version = client.versions.get_by_application_key_and_version(org, application, version)
+        found = i
+        break
+      rescue Io::Apibuilder::Api::V0::HttpClient::ServerError => e
+        # Continue looking when the version is not found; fail for other exceptions.
+        if e.code != 404
+          raise e
+        end
       end
     end
+    break unless found.nil?
   end
   found
 end
@@ -357,9 +360,9 @@ elsif command == "upload"
     if !head.nil? && system("git diff --exit-code --quiet HEAD~#{head} HEAD #{path}") && !force
       # Don't bother uploading a new version if there is no diff between the last version and
       # the current commit. Allow uploading if --force is used.
-      puts "No diff from last tag on file [${path}]. Please either specify a --version or use the --force flag."
+      puts "No diff from last tag on file [#{path}]. Please either specify a --version or use the --force flag."
     else
-      default_version = ApibuilderCli::Git.safe_describe
+      default_version = ApibuilderCli::Git.generate_version
 
       if silent
         # Don't prompt for a version when in --silent mode.

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -364,7 +364,11 @@ elsif command == "upload"
       if silent
         # Don't prompt for a version when in --silent mode.
         version = default_version
-        puts "Generated version [#{version}]"
+        if version == ""
+          puts "WARNING: No version generated; #{path} will not be uploaded to ApiBuilder until there is at least one tagged version."
+        else
+          puts "Generated version [#{version}]"
+        end
       else
         print "Version"
         if default_version != ""

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -51,6 +51,10 @@
 #    parameter. Invokes the apibuilder code generators specified in the
 #    configuration file.
 #
+# apibuilder clean apicollective apibuilder-api [--silent]
+#  - Interactively deletes from ApiBuilder any version not tagged in the source repo.
+#  - Using the --silent flag will delete versions without asking.
+#
 # apibuilder cli version
 #  - Displays the current version of the CLI
 #
@@ -498,6 +502,56 @@ elsif command == "update"
     end
   end
   tracked_files.save!
+
+elsif command == "clean"
+  org = ARGV.shift.to_s.strip
+  application = ARGV.shift.to_s.strip
+
+  args = ApibuilderCli::Args.parse(ARGV)
+  silent = args.key?(:silent)
+  limit = 50
+
+  if org.empty? || application.empty?
+    puts "org, application are required"
+    exit(1)
+  end
+
+  # This is a brute-force implementation. We could consider doing fancier things (such as
+  # only cleaning back to the most recent tag and providing a flag to clean "all"), but
+  # for simplicity and reduced bugs, let's use the naive implementation until it proves
+  # burdensome.
+  offset = 0
+  versions = []
+  # Must load all versions up front, since deleting will disrupt the clean pagination.
+  loop do
+    current_page = client.versions.get_by_application_key(org, application, :limit => limit, :offset => offset).each do |v|
+      versions << v.version
+    end
+    offset += 1
+    break if current_page.size < limit
+  end
+  to_delete = versions - ApibuilderCli::Git.tag_list
+  if to_delete.size == 0
+    puts "API is clean"
+  else
+    to_delete.each do |version|
+      delete = false
+      if silent
+        delete = true
+      else
+        print "Delete #{version} [Yn]? "
+        answer = $stdin.gets
+        delete = answer.strip.empty? || answer.strip.downcase == "y"
+      end
+      if delete
+        client.versions.delete_by_application_key_and_version(org, application, version)
+        puts "deleted #{version}..."
+      else
+        puts "skipping #{version}..."
+      end
+    end
+  end
+
 
 elsif command == "cli"
   subcommand = ARGV.shift.to_s.strip

--- a/src/apibuilder-cli/git.rb
+++ b/src/apibuilder-cli/git.rb
@@ -6,6 +6,19 @@ module ApibuilderCli
       `git rev-parse --abbrev-ref HEAD`.strip
     end
 
+    def Git.generate_version(commits_back = nil, legacy = false)
+      raw_version = Git.safe_describe(commits_back)
+      if raw_version == ""
+        ""
+      elsif legacy
+        raw_version
+      else
+        branch = Git.current_branch.downcase
+        suffix = branch == "master" ? "" : "-#{branch}"
+        "#{raw_version}#{suffix}"
+      end
+    end
+
     def Git.safe_describe(commits_back = nil)
       head = commits_back.nil? ? "" : "HEAD~#{commits_back}"
       system("git describe #{head} > /dev/null 2>&1") ? `git describe #{head}`.strip : ""

--- a/src/apibuilder-cli/git.rb
+++ b/src/apibuilder-cli/git.rb
@@ -2,6 +2,10 @@ module ApibuilderCli
 
   module Git
 
+    def Git.current_branch
+      `git rev-parse --abbrev-ref HEAD`.strip
+    end
+
     def Git.safe_describe(commits_back = nil)
       head = commits_back.nil? ? "" : "HEAD~#{commits_back}"
       system("git describe #{head} > /dev/null 2>&1") ? `git describe #{head}`.strip : ""

--- a/src/apibuilder-cli/git.rb
+++ b/src/apibuilder-cli/git.rb
@@ -16,12 +16,10 @@ module ApibuilderCli
       `git rev-parse --abbrev-ref HEAD`.strip
     end
 
-    def Git.generate_version(commits_back = nil, legacy = false)
+    def Git.generate_version(commits_back = nil)
       raw_version = Git.safe_describe(commits_back)
       if raw_version == ""
         ""
-      elsif legacy
-        raw_version
       else
         branch = Git.current_branch.downcase
         if branch == "master"

--- a/src/apibuilder-cli/git.rb
+++ b/src/apibuilder-cli/git.rb
@@ -4,7 +4,7 @@ module ApibuilderCli
 
     def Git.safe_describe(commits_back = nil)
       head = commits_back.nil? ? "" : "HEAD~#{commits_back}"
-      system("git describe #{head} 2> /dev/null") ? `git describe #{head}`.strip : ""
+      system("git describe #{head} > /dev/null 2>&1") ? `git describe #{head}`.strip : ""
     end
 
   end

--- a/src/apibuilder-cli/git.rb
+++ b/src/apibuilder-cli/git.rb
@@ -14,8 +14,11 @@ module ApibuilderCli
         raw_version
       else
         branch = Git.current_branch.downcase
-        suffix = branch == "master" ? "" : "-#{branch}"
-        "#{raw_version}#{suffix}"
+        if branch == "master"
+          raw_version
+        else
+          "#{raw_version}-#{branch}"
+        end
       end
     end
 

--- a/src/apibuilder-cli/git.rb
+++ b/src/apibuilder-cli/git.rb
@@ -24,6 +24,10 @@ module ApibuilderCli
       system("git describe #{head} > /dev/null 2>&1") ? `git describe #{head}`.strip : ""
     end
 
+    def Git.tag_list
+      `git tag --list`.strip.split("\n")
+    end
+
   end
 
 end

--- a/src/apibuilder-cli/git.rb
+++ b/src/apibuilder-cli/git.rb
@@ -8,6 +8,10 @@ module ApibuilderCli
       "-b#{Git.small_hash(branch)}-#{branch}"
     end
 
+    def Git.checkout(branch)
+      `git checkout #{branch}`
+    end
+
     def Git.current_branch
       `git rev-parse --abbrev-ref HEAD`.strip
     end
@@ -29,6 +33,16 @@ module ApibuilderCli
           # name for readability.
           "#{raw_version}#{Git.branch_suffix(branch)}"
         end
+      end
+    end
+
+    def Git.in_branch(branch)
+      current_branch = ApibuilderCli::Git.current_branch
+      ApibuilderCli::Git.checkout(branch) unless current_branch == branch
+      begin
+        yield
+      ensure
+        ApibuilderCli::Git.checkout(current_branch) unless ApibuilderCli::Git.current_branch == current_branch
       end
     end
 

--- a/test/spec/lib/git_spec.rb
+++ b/test/spec/lib/git_spec.rb
@@ -33,12 +33,19 @@ describe ApibuilderCli::Git do
         system("git tag -a 0.0.1 -m 'Initial tag'")
         system("touch temp2.txt; git add temp2.txt; git commit -m 'Second commit' &> /dev/null")
         system("touch temp3.txt; git add temp3.txt; git commit -m 'Third commit' &> /dev/null")
+        system("touch temp4.txt; git add temp4.txt; git commit -m 'Fourth commit' &> /dev/null")
+        system("git tag -a 0.0.2 -m 'Second tag'")
+        system("touch temp5.txt; git add temp5.txt; git commit -m 'Fifth commit' &> /dev/null")
         expect(ApibuilderCli::Git.safe_describe).to eq ApibuilderCli::Git.safe_describe(0)
         tag = ApibuilderCli::Git.safe_describe
-        expect(tag).to match /0\.0\.1-2-g[0-9a-f]{7}/
+        expect(tag).to match /0\.0\.2-1-g[0-9a-f]{7}/
         tag = ApibuilderCli::Git.safe_describe(1)
-        expect(tag).to match /0\.0\.1-1-g[0-9a-f]{7}/
+        expect(tag).to eq "0.0.2"
         tag = ApibuilderCli::Git.safe_describe(2)
+        expect(tag).to match /0\.0\.1-2-g[0-9a-f]{7}/
+        tag = ApibuilderCli::Git.safe_describe(3)
+        expect(tag).to match /0\.0\.1-1-g[0-9a-f]{7}/
+        tag = ApibuilderCli::Git.safe_describe(4)
         expect(tag).to eq "0.0.1"
       end
     end

--- a/test/spec/lib/git_spec.rb
+++ b/test/spec/lib/git_spec.rb
@@ -2,6 +2,14 @@ load File.join(File.dirname(__FILE__), '../../init.rb')
 
 describe ApibuilderCli::Git do
 
+  describe "#branch_suffix" do
+
+    it "should work" do
+      expect(ApibuilderCli::Git.branch_suffix("my-branch")).to eq "-b663c692-my-branch"
+    end
+
+  end
+
   describe "#safe_describe" do
 
     it "should work for tagged repos" do
@@ -91,7 +99,7 @@ describe ApibuilderCli::Git do
         system("git tag -a 0.0.1 -m 'Initial tag'")
         system_quiet("git checkout -b other")
         version = ApibuilderCli::Git.generate_version
-        expect(version).to eq "0.0.1-other"
+        expect(version).to eq "0.0.1-bd0941e6-other"
       end
     end
 
@@ -125,7 +133,7 @@ describe ApibuilderCli::Git do
         system_quiet("git checkout -b other")
         system("touch temp2.txt; git add temp2.txt; git commit -m 'Second commit' &> /dev/null")
         version = ApibuilderCli::Git.generate_version
-        expect(version).to match /^0\.0\.1-1-g[0-9a-f]{7}-other$/
+        expect(version).to match /^0\.0\.1-1-g[0-9a-f]{7}-bd0941e6-other$/
       end
     end
 
@@ -152,11 +160,11 @@ describe ApibuilderCli::Git do
         system("touch temp3.txt; git add temp3.txt; git commit -m 'Third commit' &> /dev/null")
         expect(ApibuilderCli::Git.generate_version).to eq ApibuilderCli::Git.generate_version(0)
         version = ApibuilderCli::Git.generate_version
-        expect(version).to match /^0\.0\.1-2-g[0-9a-f]{7}-other$/
+        expect(version).to match /^0\.0\.1-2-g[0-9a-f]{7}-bd0941e6-other$/
         version = ApibuilderCli::Git.generate_version(1)
-        expect(version).to match /^0\.0\.1-1-g[0-9a-f]{7}-other$/
+        expect(version).to match /^0\.0\.1-1-g[0-9a-f]{7}-bd0941e6-other$/
         version = ApibuilderCli::Git.generate_version(2)
-        expect(version).to eq "0.0.1-other"
+        expect(version).to eq "0.0.1-bd0941e6-other"
       end
     end
 
@@ -173,6 +181,20 @@ describe ApibuilderCli::Git do
         expect(version).to match /^0\.0\.1-1-g[0-9a-f]{7}$/
         version = ApibuilderCli::Git.generate_version(2, true)
         expect(version).to eq "0.0.1"
+      end
+    end
+
+  end
+
+  describe "#small_hash" do
+
+    it "should work" do
+      expect(ApibuilderCli::Git.small_hash("foo")).to eq "0beec7b"
+    end
+
+    it "should be the correct length" do
+      1.upto(50).each do
+        expect(ApibuilderCli::Git.small_hash(rand(10000).to_s).size).to eq 7
       end
     end
 

--- a/test/spec/lib/git_spec.rb
+++ b/test/spec/lib/git_spec.rb
@@ -171,6 +171,27 @@ describe ApibuilderCli::Git do
 
   end
 
+  describe "#tag_list" do
+
+    it "should work for tagged repos" do
+      with_repo do |dir|
+        system("git tag -a 0.0.1 -m 'Initial tag'")
+        system("touch temp2.txt; git add temp2.txt; git commit -m 'Second commit' &> /dev/null")
+        system("git tag -a 0.0.2 -m 'Initial tag'")
+        tags = ApibuilderCli::Git.tag_list
+        expect(tags).to eq ["0.0.1", "0.0.2"]
+      end
+    end
+
+    it "should work for repos with no tags" do
+      with_repo do |dir|
+        tags = ApibuilderCli::Git.tag_list
+        expect(tags).to eq []
+      end
+    end
+
+  end
+
 end
 
 def system_quiet(cmd)

--- a/test/spec/lib/git_spec.rb
+++ b/test/spec/lib/git_spec.rb
@@ -45,6 +45,30 @@ describe ApibuilderCli::Git do
 
   end
 
+  describe "#current_branch" do
+
+    it "should detect master" do
+      with_repo do |dir|
+        expect(ApibuilderCli::Git.current_branch).to eq "master"
+      end
+    end
+
+    it "should detect other" do
+      with_repo do |dir|
+        system("git checkout -b other")
+        expect(ApibuilderCli::Git.current_branch).to eq "other"
+      end
+    end
+
+    it "should detect master when other exists" do
+      with_repo do |dir|
+        system("git checkout -b other; git checkout master")
+        expect(ApibuilderCli::Git.current_branch).to eq "master"
+      end
+    end
+
+  end
+
 end
 
 def with_repo()

--- a/test/spec/lib/git_spec.rb
+++ b/test/spec/lib/git_spec.rb
@@ -182,22 +182,6 @@ describe ApibuilderCli::Git do
       end
     end
 
-    it "should work for previous commits on other branch with legacy flag" do
-      with_repo do |dir|
-        system("git tag -a 0.0.1 -m 'Initial tag'")
-        system_quiet("git checkout -b other")
-        system("touch temp2.txt; git add temp2.txt; git commit -m 'Second commit' &> /dev/null")
-        system("touch temp3.txt; git add temp3.txt; git commit -m 'Third commit' &> /dev/null")
-        expect(ApibuilderCli::Git.generate_version).to eq ApibuilderCli::Git.generate_version(0)
-        version = ApibuilderCli::Git.generate_version(nil, true)
-        expect(version).to match /^0\.0\.1-2-g[0-9a-f]{7}$/
-        version = ApibuilderCli::Git.generate_version(1, true)
-        expect(version).to match /^0\.0\.1-1-g[0-9a-f]{7}$/
-        version = ApibuilderCli::Git.generate_version(2, true)
-        expect(version).to eq "0.0.1"
-      end
-    end
-
   end
 
   describe "#in_branch" do


### PR DESCRIPTION
This will be useful when cleaning up versions, so branches can be cleaned up individually.