### PR TITLE
Option in upload command to write the version back to local config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To view a list of available generators visit [apibuilder.io/generators](https://
 Upload a new version of an api given the json descriptor.
 
 ```
-bin/apibuilder upload <organization key> <application key> <file> --version <version> [--force] [--silent]
+bin/apibuilder upload <organization key> <application key> <file> --version <version> [--force] [--silent] [--update-config <optional path>]
 ```
 
 For example:
@@ -82,6 +82,8 @@ bin/apibuilder upload apicollective apibuilder-api apibuilder-api/api.json --ver
 The `--force` flag will allow you to re-upload an api.json even if there are no changes since the previously uploaded version.
 
 When using the `--silent` flag, the suggested tag will be automatically used. This is useful for automated uploading via git hooks and/or CD pipelines.
+
+The `--update-config` flag tells the cli to update the local `.apibuilder/config` with the new version of the given api. It uses either the default path or the path given in the argument.
 
 ## update
 

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -41,7 +41,7 @@
 # apibuilder example apicollective apibuilder-api latest type
 #  - Generates an example JSON document for the specified type
 #
-# apibuilder upload apicollective apibuilder-api api/api.json [--version 1.5.0-dev] [--force] [--silent]
+# apibuilder upload apicollective apibuilder-api api/api.json [--version 1.5.0-dev] [--force] [--silent] [--update-config optional-file-path]
 #  - Uploads the file api/api.json to the apicollective org, apibuilder application.
 #    The uploaded file will be the specified version, defaulting to
 #    the output from git describe.
@@ -125,6 +125,18 @@ def head_of_latest_uploaded_version(org, application, client)
     end
   end
   found
+end
+
+def get_app_config_from_argument(argName)
+  args = ApibuilderCli::Args.parse(ARGV)
+  path = File.expand_path(args[argName] || ApibuilderCli::AppConfig.default_path)
+
+  if !File.exists?(path)
+    puts "Apibuilder config file #{path} does not exist"
+    exit(1)
+  end
+
+  ApibuilderCli::AppConfig.new(:path => path)
 end
 
 # Apibuilder injects a few comments into the code base to identify
@@ -360,6 +372,7 @@ elsif command == "upload"
 
   args = ApibuilderCli::Args.parse(ARGV)
   force = args.key?(:force)
+  update_config = args.key?(:'update-config')
   silent = args.key?(:silent)
   version = args[:version].to_s.strip
 
@@ -412,21 +425,18 @@ elsif command == "upload"
 
   unless version.empty?
     upload_version(client, org, application, version, IO.read(path), path)
+    if update_config
+      app_config = get_app_config_from_argument(:'update-config')
+      app_config.set_version(org, application, version)
+      app_config.save!
+    end
   end
 
 elsif command == "update"
-  args = ApibuilderCli::Args.parse(ARGV)
-  path = File.expand_path(args[:path] || ApibuilderCli::AppConfig.default_path)
-
-  if !File.exists?(path)
-    puts "File #{path} does not exit"
-    exit(1)
-  end
+  app_config = get_app_config_from_argument(:path)
 
   updates = []
   puts "Fetching code from #{client.url}"
-
-  app_config = ApibuilderCli::AppConfig.new(:path => path)
 
   tracked_files = ApibuilderCli::FileTracker.new(app_config.project_dir)
 

--- a/test/spec/lib/app_config_spec.rb
+++ b/test/spec/lib/app_config_spec.rb
@@ -36,6 +36,8 @@ describe ApibuilderCli::AppConfig do
 
     before do
       @sample_file = ApibuilderCli::Util.write_to_temp_file("""
+settings:
+  code.create.directories: true
 code:
   apicollective:
     apibuilder:
@@ -64,6 +66,7 @@ code:
       app_config = ApibuilderCli::AppConfig.new(:path => @sample_file)
       expect(app_config.code.projects.map(&:name).sort).to eq(["apibuilder", "apibuilder-generator", "apibuilder-spec", "bar"])
 
+      expect(app_config.settings.code_create_directories).to eq(true)
       apibuilder = app_config.code.projects.find { |p| p.name == "apibuilder" }
       expect(apibuilder.org).to eq("apicollective")
       expect(apibuilder.name).to eq("apibuilder")
@@ -74,6 +77,40 @@ code:
       expect(bar.org).to eq("foo")
       expect(bar.name).to eq("bar")
       expect(bar.version).to eq("0.0.1")
+      expect(bar.generators.map(&:name).sort).to eq(["ruby_client"])
+    end
+
+    it "sets version and writes file" do
+      app_config = ApibuilderCli::AppConfig.new(:path => @sample_file)
+      expect(app_config.settings.code_create_directories).to eq(true)
+
+      apibuilder = app_config.code.projects.find { |p| p.name == "apibuilder" }
+      expect(apibuilder.org).to eq("apicollective")
+      expect(apibuilder.name).to eq("apibuilder")
+      expect(apibuilder.version).to eq("latest")
+      expect(apibuilder.generators.map(&:name).sort).to eq(["play_2_3_client", "play_2_x_routes"])
+
+      bar = app_config.code.projects.find { |p| p.name == "bar" }
+      expect(bar.org).to eq("foo")
+      expect(bar.name).to eq("bar")
+      expect(bar.version).to eq("0.0.1")
+      expect(bar.generators.map(&:name).sort).to eq(["ruby_client"])
+
+      app_config.set_version("foo", "bar", "0.0.2")
+      app_config.save!
+
+      app_config = ApibuilderCli::AppConfig.new(:path => @sample_file)
+
+      apibuilder = app_config.code.projects.find { |p| p.name == "apibuilder" }
+      expect(apibuilder.org).to eq("apicollective")
+      expect(apibuilder.name).to eq("apibuilder")
+      expect(apibuilder.version).to eq("latest")
+      expect(apibuilder.generators.map(&:name).sort).to eq(["play_2_3_client", "play_2_x_routes"])
+
+      bar = app_config.code.projects.find { |p| p.name == "bar" }
+      expect(bar.org).to eq("foo")
+      expect(bar.name).to eq("bar")
+      expect(bar.version).to eq("0.0.2")
       expect(bar.generators.map(&:name).sort).to eq(["ruby_client"])
     end
 


### PR DESCRIPTION
This is helpful for repos that control an api document (and are thus
uploading it to Apibuilder) but also use the same document to generate
code locally in the repo. Using "latest" as the version doesn't work
for non-semver (i.e. "development") versions uploaded to Apibuilder.
Also, doing something like "most recent uploaded version" does not
work for repos with multiple people working on multiple branches. So
it is easiest to store the version in the local config and automatically
update it as part of the workflow.