### PR TITLE
.tracked_files -> tracked_files

### DIFF
--- a/src/apibuilder-cli/file_tracker.rb
+++ b/src/apibuilder-cli/file_tracker.rb
@@ -3,7 +3,7 @@ module ApibuilderCli
   class FileTracker
 
     def FileTracker.default_path(project_dir)
-      Util.file_join(project_dir, ApibuilderCli::Config::APIBUILDER_LOCAL_DIR, ".tracked_files")
+      Util.file_join(project_dir, ApibuilderCli::Config::APIBUILDER_LOCAL_DIR, "tracked_files")
     end
 
     # Options:


### PR DESCRIPTION
`.tracked_files` is already in a hidden directory, `.apibuilder`, so there's no need to hide this file as well