### PR TITLE
fix .tracked_files when updating with --org & --app

### DIFF
--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -437,7 +437,8 @@ elsif command == "update"
   updates = []
   puts "Fetching code from #{client.url}"
 
-  tracked_files = ApibuilderCli::FileTracker.new(app_config.project_dir)
+  subset = !args[:org].nil? || !args[:app].nil? # if we are only updating a subset of the files
+  tracked_files = ApibuilderCli::FileTracker.new(app_config.project_dir, subset: subset)
 
   app_config.code.projects.select { |s|
     (args[:org].nil? || s.org == args[:org]) && (args[:app].nil? || args[:app].include?(s.name))

--- a/src/apibuilder-cli/file_tracker.rb
+++ b/src/apibuilder-cli/file_tracker.rb
@@ -25,6 +25,11 @@ module ApibuilderCli
                       end
         end
       end
+      @subset = !!opts.delete(:subset)
+      if @subset
+        @current = @previous
+        @current_raw = @previous.values.flat_map(&:values).flat_map(&:values)
+      end
     end
 
     # Saves the tracked file list to the file
@@ -67,7 +72,9 @@ module ApibuilderCli
       @current[org][project][generator] << file
       @current_raw << file
 
-      @previous[org][project][generator].select!{ |previous_file| previous_file != file } if @previous[org] && @previous[org][project] && @previous[org][project][generator]
+      if !@subset
+        @previous[org][project][generator].select!{ |previous_file| previous_file != file } if @previous[org] && @previous[org][project] && @previous[org][project][generator]
+      end
     end
 
   end


### PR DESCRIPTION
Here is an example of what happens when you use this currently: https://github.com/flowcommerce/billing/commit/6d668c1718dcf3130ae8b99b5c313d8d7698cf8c#diff-dbdaf0e93daabdcf2d530641916413cb

This PR fixes that.