### PR TITLE
improve error message for invalid config file

### DIFF
--- a/src/apibuilder-cli/config.rb
+++ b/src/apibuilder-cli/config.rb
@@ -87,6 +87,16 @@ module ApibuilderCli
         else
           name, value = stripped.split(/\s*=\s*/, 2).map(&:strip)
 
+          if @profiles[-1].nil?
+            puts "**ERROR** Missing profile block in configuration at #{@path}."
+            puts ''
+            puts "Example:"
+            puts ''
+            puts '[default]'
+            puts 'token = <api token>'
+            exit(1)
+          end
+
           if name != "" && value != ""
             @profiles[-1].add(name, value)
           end


### PR DESCRIPTION
If there is no `[profile]` block, we crash with a stack trace right now.

old:
```
❯ read-config
/Users/ben/dev/apibuilder-cli/src/apibuilder-cli/config.rb:92:in `block in initialize': undefined method `add' for nil:NilClass (NoMethodError)
	from /Users/ben/dev/apibuilder-cli/src/apibuilder-cli/config.rb:65:in `each'
	from /Users/ben/dev/apibuilder-cli/src/apibuilder-cli/config.rb:65:in `each_with_index'
	from /Users/ben/dev/apibuilder-cli/src/apibuilder-cli/config.rb:65:in `initialize'
	from /Users/ben/dev/apibuilder-cli/bin/read-config:16:in `new'
	from /Users/ben/dev/apibuilder-cli/bin/read-config:16:in `<main>'
```

new:
```
❯ read-config
**ERROR** Missing profile block in configuration at /Users/ben/.apibuilder/config.

Example:

[default]
token = <api token>
```