### PR TITLE
Fix .tracked_files changing when updating a single app

### DIFF
--- a/src/apibuilder-cli/file_tracker.rb
+++ b/src/apibuilder-cli/file_tracker.rb
@@ -88,8 +88,6 @@ module ApibuilderCli
       @current[org][project][generator] = [] if @current[org][project][generator].nil?
       @current[org][project][generator] << file
       @current_raw << file
-
-      @previous[org][project][generator].select!{ |previous_file| previous_file != file } if @previous[org] && @previous[org][project] && @previous[org][project][generator]
     end
 
   end


### PR DESCRIPTION
When I run `apibuilder update --app <something>` I see incorrect deleted
lines in `.tracked_files`. The issue is that we are modifying an array
while iterating over it.
