### PR TITLE
Use multiple threads to execute ApiBuilder update

### DIFF
--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -254,6 +254,14 @@ def upload_version(client, org, application, version, data, path = "")
   end
 end
 
+class ProjectWithGenerator
+  attr_reader :project, :generator
+  def initialize(project, generator)
+    @project = project
+    @generator = generator
+  end
+end
+
 if command == "list"
   resource = ARGV.shift.to_s.strip
 
@@ -492,65 +500,77 @@ elsif command == "update"
   updating_only = (args[:org].nil? && args[:app].nil?) ? nil : { :org => args[:org], :app => args[:app] }
   tracked_files = ApibuilderCli::FileTracker.new(app_config.project_dir, { :updating_only => updating_only })
 
-  app_config.code.projects.select { |s|
+  all = app_config.code.projects.select { |s|
     (args[:org].nil? || s.org == args[:org]) && (args[:app].nil? || args[:app].include?(s.name))
   }.map do |project|
-    project.generators.each do |generator|
-      generator.targets.each do |target|
-        puts "  #{project.org}/#{project.name}/#{project.version}/#{generator.name}..."
-        base_target_path = File.join(app_config.project_dir, target)
-        reference_target_path = File.join(app_config.project_dir, ApibuilderCli::Config::APIBUILDER_LOCAL_DIR, target)
+    project.generators.map { |generator|
+      puts "  #{project.org}/#{project.name}/#{project.version}/#{generator.name}..."
+      ProjectWithGenerator.new(project, generator)
+    }
+  end.flatten
 
-        begin
-          attributes = generator.attributes.map { |k, v| Io::Apibuilder::Generator::V0::Models::Attribute.new(:name => k, :value => v) }
-          form = Io::Apibuilder::Api::V0::Models::CodeForm.new(:attributes => attributes)
-          code = ApibuilderCli::Util.call(client) do
-            client.code.post_by_generator_key(project.org, project.name, project.version, generator.name, form).files
-          end
-          if generator.files.nil?
-            files = code
-          else
-            files = filter_files(generator.files, code, generator.name)
-          end
-          files.each do |f|
-            # For scaffolding (i.e. locally-editable) files, store a copy of the original in the .apibuilder directory in order to
-            # demonstrate diffs to be manually ported to the scaffolding files.
-            [[f, base_target_path], file_is_scaffolding?(f) ? [Io::Apibuilder::Generator::V0::Models::File.new(f.to_hash.merge(:flags => nil)), reference_target_path] : nil].compact.each do |file, file_target_path|
-              final_target_path = app_config.settings.code_create_directories && file.dir ? File.join(file_target_path, file.dir) : file_target_path
+  all.each_slice(15) do |pairs|
+    threads = pairs.map do |pair|
+      Thread.new do
+        project = pair.project
+        generator = pair.generator
 
-              # check if target path ends with the filename - if not, this is a directory target and need to check if dir exists
-              # for example: "play_2_x_routes: api/conf/routes" is a file
-              # while "anorm_2_x_parsers: api/app/generated" should be a directory we check if exists
-              FileUtils.mkdir_p(final_target_path) unless final_target_path.include?(file.name) || Dir.exist?(final_target_path) || File.exist?(final_target_path)
+        generator.targets.each do |target|
+          base_target_path = File.join(app_config.project_dir, target)
+          reference_target_path = File.join(app_config.project_dir, ApibuilderCli::Config::APIBUILDER_LOCAL_DIR, target)
 
-              target_path = File.directory?(final_target_path) ? File.join(final_target_path, file.name) : final_target_path
-              existing_source = File.exist?(target_path) ? IO.read(target_path).strip : ""
+          begin
+            attributes = generator.attributes.map { |k, v| Io::Apibuilder::Generator::V0::Models::Attribute.new(:name => k, :value => v) }
+            form = Io::Apibuilder::Api::V0::Models::CodeForm.new(:attributes => attributes)
+            code = ApibuilderCli::Util.call(client) do
+              client.code.post_by_generator_key(project.org, project.name, project.version, generator.name, form).files
+            end
+            if generator.files.nil?
+              files = code
+            else
+              files = filter_files(generator.files, code, generator.name)
+            end
+            files.each do |f|
+              # For scaffolding (i.e. locally-editable) files, store a copy of the original in the .apibuilder directory in order to
+              # demonstrate diffs to be manually ported to the scaffolding files.
+              [[f, base_target_path], file_is_scaffolding?(f) ? [Io::Apibuilder::Generator::V0::Models::File.new(f.to_hash.merge(:flags => nil)), reference_target_path] : nil].compact.each do |file, file_target_path|
+                final_target_path = app_config.settings.code_create_directories && file.dir ? File.join(file_target_path, file.dir) : file_target_path
 
-              print "    " + target_path.sub(/^#{app_config.project_dir}\/?/, '') + ": "
-              if file_is_scaffolding?(file)
-                if existing_source == ""
-                  puts "new scaffolding file"
-                  updates << { :source => file.contents, :generator => generator.name, :target => target_path }
+                # check if target path ends with the filename - if not, this is a directory target and need to check if dir exists
+                # for example: "play_2_x_routes: api/conf/routes" is a file
+                # while "anorm_2_x_parsers: api/app/generated" should be a directory we check if exists
+                FileUtils.mkdir_p(final_target_path) unless final_target_path.include?(file.name) || Dir.exist?(final_target_path) || File.exist?(final_target_path)
+
+                target_path = File.directory?(final_target_path) ? File.join(final_target_path, file.name) : final_target_path
+                existing_source = File.exist?(target_path) ? IO.read(target_path).strip : ""
+
+                print "    " + target_path.sub(/^#{app_config.project_dir}\/?/, '') + ": "
+                if file_is_scaffolding?(file)
+                  if existing_source == ""
+                    puts "new scaffolding file"
+                    updates << { :source => file.contents, :generator => generator.name, :target => target_path }
+                  else
+                    puts "scaffolding file - ignoring"
+                  end
                 else
-                  puts "scaffolding file - ignoring"
+                  if different?(file.contents, existing_source)
+                    puts "changed"
+                    updates << { :source => file.contents, :generator => generator.name, :target => target_path }
+                  else
+                    puts "unchanged"
+                  end
+                  tracked_files.track!(project.org, project.name, generator.name, target_path)
                 end
-              else
-                if different?(file.contents, existing_source)
-                  puts "changed"
-                  updates << { :source => file.contents, :generator => generator.name, :target => target_path }
-                else
-                  puts "unchanged"
-                end
-                tracked_files.track!(project.org, project.name, generator.name, target_path)
               end
             end
+          rescue Exception => e
+            handle_server_error(e)
           end
-        rescue Exception => e
-          handle_server_error(e)
+          puts ""
         end
-        puts ""
       end
     end
+    threads.each(&:join)
   end
 
   puts ""

--- a/bin/apibuilder
+++ b/bin/apibuilder
@@ -80,6 +80,8 @@
 
 load File.join(File.dirname(__FILE__), '../src/apibuilder-cli.rb')
 
+MAX_THREADS = 15
+
 env = {
   :profile => ApibuilderCli::Util.read_non_empty_string(ENV['PROFILE']),
   :apibuilder_token => ApibuilderCli::Util.read_non_empty_string(ENV['APIBUILDER_TOKEN']) || ApibuilderCli::Util.read_non_empty_string(ENV['APIDOC_TOKEN']),
@@ -509,7 +511,7 @@ elsif command == "update"
     }
   end.flatten
 
-  all.each_slice(15) do |pairs|
+  all.each_slice(MAX_THREADS) do |pairs|
     threads = pairs.map do |pair|
       Thread.new do
         project = pair.project


### PR DESCRIPTION
Use up to 15 threads to fetch updated code. Seeing improvement in time from ~60 seconds to ~10 seconds.